### PR TITLE
Fixed writing issues in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,15 +6,16 @@ For any feature requests, or bugs, please open an issue.
 
 ## About
 
-C generics typically use `void *` which is type unsafe, and often slow. This library aims to provide a simple implementation of generic vectors in C with type safety using some tricky macros.
+C generics typically use `void *`. Void is type unsafe, and slow. c_vector library aims to provide an implementation of generic vectors in C with type safety using tricky macros.
 
 ## Usage
 
 ### Quickstart
 
-You will need to copy `gen_vector.h`, `vector.h`, and `vector.c` into your project first.
 
-There is a little more work required to use this library than a template in other languages. You must know ahead of time which types you want to use, and declare them. Compilation will fail if you try to use the vector for types you have not yet declared. Declaration is performed by modifying `gen_vector.h`. For example, if you wished to use the vector library for type `int` and type `float`, then you would add the following lines to `gen_vector.h`:
+Copy `gen_vector.h`, `vector.h`, and `vector.c` into your project first.
+
+The c_vector library cannot be simply used as a template. More work is required to use the library. Types should be known and declared ahead of time. Using vectors for undeclared types will result in failed compilation. Types can be declared by modifying `gen_vector.h`. For example, add the following lines to `gen_vector.h` to use the vector library for type `int` and type `float`:
 
 ``` C
 #define T int
@@ -26,7 +27,7 @@ There is a little more work required to use this library than a template in othe
 #undef T
 ```
 
-This will expose the functions of the vector library. The header file to use the vector container is `gen_vector.h`
+The code above exposes the functions of the vector library. The header file to use the vector container is `gen_vector.h`
 
 ```C
 #include "gen_vector.h"
@@ -52,15 +53,16 @@ int main (int argv, char **argc) {
 
 ### API
 
-Available functions are as follows. replace `foo` below with any type you have declared as above
+
+Available functions are as follows (replace `foo` with any type declared above)
 
 #### `void foo_vec_init (foo_vec* vector)`
 
-Initialises the vector. Call this before any other functions.
+Initializes the vector. Call vector initialize before other functions.
 
 #### `void foo_vec_free (foo_vec* vector)`
 
-Deallocates memory requested for the vector. Call this when the vector is no longer required.
+Deallocates memory requested for the vector. The function is called when the vector is no longer required.
 
 #### `size_t foo_vec_length (foo_vec* vector)`
 
@@ -68,11 +70,11 @@ Returns the (logical) length of the vector.
 
 #### `size_t foo_vec_push (foo_vec* vector, foo elem)`
 
-Push an element onto the end of the vector. On success, returns the new length of the vector. On failure, (insufficient memory) this function returns 0, and leaves the vector unmodified.
+Push an element onto the end of the vector. On success, returns the new length of the vector. On failure, (insufficient memory) returns 0, and leaves the vector unmodified.
 
 #### `foo foo_vec_pop (foo_vec* vector)`
 
-Removes an element from the end of the vector. Returns the element.
+Removes and return an element from the end of the vector.
 
 #### `void foo_vec_set (foo_vec* vector, size_t index, foo elem)`
 
@@ -84,7 +86,7 @@ Returns the element at `index`.
 
 #### `size_t foo_vec_insert ( foo_vec* vector, size_t index, foo elem)`
 
-Inserts a single element at a position given by 'index' and shifts the rest of the elements over by one. Returns the length of the vector on success, and on allocation failure, returns `0` and leaves the vector unmodified.
+Inserts a single element at a position given by 'index' and shifts the rest of the elements over by one. Returns the length of the vector on success. Returns `0` and leaves the vector unmodified on failure.
 
 #### `void foo_vec_delete ( foo_vec* vector, size_t index)`
 
@@ -92,4 +94,4 @@ Deletes the element at `index`.
 
 #### `size_t foo_vec_reserve ( foo_vec* vector, size_t psize)`
 
-Reserves enough memory for `psize` elements in the vector, but leaves the vector otherwise unmodified. Will return the new physical size of the vector. If there is an allocation failure, the old physical size is returned. If the reserved size is shorter than the length of the vector, the vector is shortened accordingly.
+Reserves enough memory for `psize` elements in the vector, but leaves the vector otherwise unmodified. Function returns the new physical size of the vector. If there is an allocation failure, the old physical size is returned. If the reserved size is shorter than the length of the vector, the vector is shortened accordingly.


### PR DESCRIPTION
Remove 'often' 'will' -> hedging word.
Remove 'simple' and 'some' -> redundant as these words do not add much to the sentences.
'replace `foo` below with any type you have declared as above' ->  replace `foo` with any type declared above) for enhanced clarity.
'this' -> the function.
Pronouns are remove as technical document should avoid pronouns when possible.
Sentence structure edited for conciseness.

Fixes #3 